### PR TITLE
Update restricted_user_allowed.txt

### DIFF
--- a/ckanext/restricted/templates/restricted/emails/restricted_user_allowed.txt
+++ b/ckanext/restricted/templates/restricted/emails/restricted_user_allowed.txt
@@ -3,7 +3,7 @@
 {% trans %}You have requested access on {{ site_title }} to the resource: {{ resource_name }}.{% endtrans %}
 {% trans %}The contact person of the package has granted you access.{% endtrans %}
 
-{% trans %}Please click the following link: {{ resource_link }}{% endtrans %}
+{% trans %}Please click the following link{% endtrans %}: {{ resource_link|safe }}
 
 {% trans %}Best regards,{% endtrans %}
 {% trans %}{{ site_title }} Administrator{% endtrans %}


### PR DESCRIPTION
Found this when working on https://unaids.org for https://fjelltopp.org:

# Problem
- Some links in emails are having their queryparam `&` symbols encoded into `&amp;` which breaks the link
- We're also accidentally wrapping links within `{% trans %}{% endtrans %}` which also breaks the link

# Solution
- Add `{{ resource_edit_link|safe }}` so characters are not encoded by jinja2
- Fix issues with having links wrongly translated